### PR TITLE
chore(sparkscan): Add API key authentication support

### DIFF
--- a/crates/sparkscan/doc/address_summary.md
+++ b/crates/sparkscan/doc/address_summary.md
@@ -16,19 +16,14 @@ Returns detailed information about an address including:
 > **Note**: The address and other values used in this example are for documentation testing purposes.
 
 ```rust
-use sparkscan::{Client, reqwest};
+use sparkscan::Client;
 
 tokio_test::block_on(async {
-    // Configure client with API key
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("x-api-key", std::env::var("X_API_KEY").unwrap_or("test".to_string()).parse().unwrap());
-
-    let http_client = reqwest::ClientBuilder::new()
-        .default_headers(headers)
-        .build()
-        .unwrap();
-
-    let client = Client::new_with_client("https://api.sparkscan.io", http_client);
+    // Create client with API key from environment
+    let client = Client::new_with_api_key(
+        "https://api.sparkscan.io",
+        &std::env::var("X_API_KEY").unwrap_or("test".to_string())
+    );
     let response = client
         .address_summary_v1_address_address_get()
         .address("sp1pgssyv42njtxa7kkgvnukk2xnuwpg96n5mxm4985lvhe6sxgavl902js39la8k")

--- a/crates/sparkscan/doc/get_address_tokens.md
+++ b/crates/sparkscan/doc/get_address_tokens.md
@@ -16,19 +16,14 @@ Returns detailed information about all tokens held by an address, including:
 > **Note**: The address and other values used in this example are for documentation testing purposes.
 
 ```rust
-use sparkscan::{Client, reqwest};
+use sparkscan::Client;
 
 tokio_test::block_on(async {
-    // Configure client with API key
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("x-api-key", std::env::var("X_API_KEY").unwrap_or("test".to_string()).parse().unwrap());
-
-    let http_client = reqwest::ClientBuilder::new()
-        .default_headers(headers)
-        .build()
-        .unwrap();
-
-    let client = Client::new_with_client("https://api.sparkscan.io", http_client);
+    // Create client with API key from environment
+    let client = Client::new_with_api_key(
+        "https://api.sparkscan.io",
+        &std::env::var("X_API_KEY").unwrap_or("test".to_string())
+    );
     let tokens = client
         .get_address_tokens_v1_address_address_tokens_get()
         .address("sp1pgssyv42njtxa7kkgvnukk2xnuwpg96n5mxm4985lvhe6sxgavl902js39la8k")

--- a/crates/sparkscan/doc/get_address_transactions.md
+++ b/crates/sparkscan/doc/get_address_transactions.md
@@ -19,19 +19,14 @@ Retrieves all transactions associated with an address, including:
 > **Note**: The address and other values used in this example are for documentation testing purposes.
 
 ```rust
-use sparkscan::{Client, reqwest};
+use sparkscan::Client;
 
 tokio_test::block_on(async {
-    // Configure client with API key
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("x-api-key", std::env::var("X_API_KEY").unwrap_or("test".to_string()).parse().unwrap());
-
-    let http_client = reqwest::ClientBuilder::new()
-        .default_headers(headers)
-        .build()
-        .unwrap();
-
-    let client = Client::new_with_client("https://api.sparkscan.io", http_client);
+    // Create client with API key from environment
+    let client = Client::new_with_api_key(
+        "https://api.sparkscan.io",
+        &std::env::var("X_API_KEY").unwrap_or("test".to_string())
+    );
     let response = client
         .get_address_transactions_v1_address_address_transactions_get()
         .address("sp1pgssyv42njtxa7kkgvnukk2xnuwpg96n5mxm4985lvhe6sxgavl902js39la8k")

--- a/crates/sparkscan/doc/get_addresses_latest_txid.md
+++ b/crates/sparkscan/doc/get_addresses_latest_txid.md
@@ -18,19 +18,14 @@ Accepts up to 100 Bitcoin addresses per request.
 > **Note**: The Bitcoin addresses and other values used in this example are for documentation testing purposes.
 
 ```rust
-use sparkscan::{Client, reqwest};
+use sparkscan::Client;
 
 tokio_test::block_on(async {
-    // Configure client with API key
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("x-api-key", std::env::var("X_API_KEY").unwrap_or("test".to_string()).parse().unwrap());
-
-    let http_client = reqwest::ClientBuilder::new()
-        .default_headers(headers)
-        .build()
-        .unwrap();
-
-    let client = Client::new_with_client("https://api.sparkscan.io", http_client);
+    // Create client with API key from environment
+    let client = Client::new_with_api_key(
+        "https://api.sparkscan.io",
+        &std::env::var("X_API_KEY").unwrap_or("test".to_string())
+    );
     
     let addresses = vec![
         "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh".to_string(),

--- a/crates/sparkscan/doc/get_latest_transactions.md
+++ b/crates/sparkscan/doc/get_latest_transactions.md
@@ -19,19 +19,14 @@ Returns recent transactions from all addresses, useful for:
 > **Note**: The values used in this example are for documentation testing purposes.
 
 ```rust
-use sparkscan::{Client, reqwest};
+use sparkscan::Client;
 
 tokio_test::block_on(async {
-    // Configure client with API key
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("x-api-key", std::env::var("X_API_KEY").unwrap_or("test".to_string()).parse().unwrap());
-
-    let http_client = reqwest::ClientBuilder::new()
-        .default_headers(headers)
-        .build()
-        .unwrap();
-
-    let client = Client::new_with_client("https://api.sparkscan.io", http_client);
+    // Create client with API key from environment
+    let client = Client::new_with_api_key(
+        "https://api.sparkscan.io",
+        &std::env::var("X_API_KEY").unwrap_or("test".to_string())
+    );
     let response = client
         .get_latest_transactions_v1_tx_latest_get()
         .network("MAINNET")

--- a/crates/sparkscan/doc/get_token_holders.md
+++ b/crates/sparkscan/doc/get_token_holders.md
@@ -18,19 +18,14 @@ Returns holders of a token with their balances and portfolio percentages, useful
 > **Note**: The token identifier and other values used in this example are for documentation testing purposes.
 
 ```rust
-use sparkscan::{Client, reqwest};
+use sparkscan::Client;
 
 tokio_test::block_on(async {
-    // Configure client with API key
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("x-api-key", std::env::var("X_API_KEY").unwrap_or("test".to_string()).parse().unwrap());
-
-    let http_client = reqwest::ClientBuilder::new()
-        .default_headers(headers)
-        .build()
-        .unwrap();
-
-    let client = Client::new_with_client("https://api.sparkscan.io", http_client);
+    // Create client with API key from environment
+    let client = Client::new_with_api_key(
+        "https://api.sparkscan.io",
+        &std::env::var("X_API_KEY").unwrap_or("test".to_string())
+    );
     let response = client
         .get_token_holders_v1_tokens_identifier_holders_get()
         .identifier("06f620d132bcef1a1bf6f132351a6436334a89332d4965b6acecf13b78156094")

--- a/crates/sparkscan/doc/get_token_leaderboard.md
+++ b/crates/sparkscan/doc/get_token_leaderboard.md
@@ -18,19 +18,14 @@ Returns a leaderboard of tokens sorted by various metrics, useful for:
 > **Note**: The values used in this example are for documentation testing purposes.
 
 ```rust
-use sparkscan::{Client, reqwest};
+use sparkscan::Client;
 
 tokio_test::block_on(async {
-    // Configure client with API key
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("x-api-key", std::env::var("X_API_KEY").unwrap_or("test".to_string()).parse().unwrap());
-
-    let http_client = reqwest::ClientBuilder::new()
-        .default_headers(headers)
-        .build()
-        .unwrap();
-
-    let client = Client::new_with_client("https://api.sparkscan.io", http_client);
+    // Create client with API key from environment
+    let client = Client::new_with_api_key(
+        "https://api.sparkscan.io",
+        &std::env::var("X_API_KEY").unwrap_or("test".to_string())
+    );
     let leaderboard = client
         .get_token_leaderboard_v1_stats_leaderboard_tokens_get()
         .network("MAINNET")

--- a/crates/sparkscan/doc/get_token_transactions.md
+++ b/crates/sparkscan/doc/get_token_transactions.md
@@ -18,19 +18,14 @@ Returns all transactions involving a specific token, including:
 > **Note**: The token identifier and other values used in this example are for documentation testing purposes.
 
 ```rust
-use sparkscan::{Client, reqwest};
+use sparkscan::Client;
 
 tokio_test::block_on(async {
-    // Configure client with API key
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("x-api-key", std::env::var("X_API_KEY").unwrap_or("test".to_string()).parse().unwrap());
-
-    let http_client = reqwest::ClientBuilder::new()
-        .default_headers(headers)
-        .build()
-        .unwrap();
-
-    let client = Client::new_with_client("https://api.sparkscan.io", http_client);
+    // Create client with API key from environment
+    let client = Client::new_with_api_key(
+        "https://api.sparkscan.io",
+        &std::env::var("X_API_KEY").unwrap_or("test".to_string())
+    );
     let response = client
         .get_token_transactions_v1_tokens_identifier_transactions_get()
         .identifier("06f620d132bcef1a1bf6f132351a6436334a89332d4965b6acecf13b78156094")

--- a/crates/sparkscan/doc/get_wallet_leaderboard.md
+++ b/crates/sparkscan/doc/get_wallet_leaderboard.md
@@ -16,19 +16,14 @@ Returns a ranked list of wallets sorted by their total portfolio value, useful f
 > **Note**: The values used in this example are for documentation testing purposes.
 
 ```rust
-use sparkscan::{Client, reqwest};
+use sparkscan::Client;
 
 tokio_test::block_on(async {
-    // Configure client with API key
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("x-api-key", std::env::var("X_API_KEY").unwrap_or("test".to_string()).parse().unwrap());
-
-    let http_client = reqwest::ClientBuilder::new()
-        .default_headers(headers)
-        .build()
-        .unwrap();
-
-    let client = Client::new_with_client("https://api.sparkscan.io", http_client);
+    // Create client with API key from environment
+    let client = Client::new_with_api_key(
+        "https://api.sparkscan.io",
+        &std::env::var("X_API_KEY").unwrap_or("test".to_string())
+    );
     let leaderboard = client
         .get_wallet_leaderboard_v1_stats_leaderboard_wallets_get()
         .network("MAINNET")

--- a/crates/sparkscan/doc/new.md
+++ b/crates/sparkscan/doc/new.md
@@ -5,7 +5,7 @@ This method creates a client using the default reqwest::Client configuration wit
 - 15-second connect and request timeouts (non-WASM targets)
 - Default headers for optimal API interaction
 
-**Important**: For production use with api.sparkscan.io, you must use `new_with_client` instead to configure the required `x-api-key` header. This method is mainly fordevelopment and testing.
+**Important**: For production use with api.sparkscan.io, you should use `new_with_api_key` instead to configure the required `x-api-key` header. This method is mainly for development and testing.
 
 ## Parameters
 
@@ -24,4 +24,5 @@ let client = Client::new("https://api.sparkscan.io");
 
 ## See Also
 
-- `new_with_client` - For custom client configuration including API keys
+- `new_with_api_key` - For production use with API keys (recommended)
+- `new_with_client` - For advanced custom client configuration

--- a/crates/sparkscan/doc/new_with_api_key.md
+++ b/crates/sparkscan/doc/new_with_api_key.md
@@ -1,0 +1,45 @@
+Create a new client with an API key for production use with api.sparkscan.io.
+
+This is the recommended method for production applications using the official SparkScan API. It automatically configures the required `x-api-key` header and sets up optimal client settings including timeouts and user-agent headers.
+
+## Parameters
+
+- `baseurl`: The base URL for the API (should be "https://api.sparkscan.io")
+- `api_key`: Your SparkScan API key
+
+## Example
+
+> **Note**: Use your actual SparkScan API key from environment variables for security.
+
+```rust
+use sparkscan::Client;
+
+tokio_test::block_on(async {
+    let client = Client::new_with_api_key(
+        "https://api.sparkscan.io", 
+        &std::env::var("X_API_KEY").unwrap_or("test".to_string())
+    );
+    
+    // Now you can use the client for API calls
+    let _response = client
+        .address_summary_v1_address_address_get()
+        .address("sp1pgssyv42njtxa7kkgvnukk2xnuwpg96n5mxm4985lvhe6sxgavl902js39la8k")
+        .network("MAINNET")
+        .send()
+        .await
+        .unwrap();
+});
+```
+
+## Benefits
+
+- **Simplified setup**: No need to manually configure headers
+- **Production-ready**: Includes proper timeouts and user-agent
+- **API key management**: Automatically handles x-api-key header
+- **Cross-platform**: Works on both WASM and native targets
+- **Secure**: Uses environment variables for API key management
+
+## See Also
+
+- `new` - For basic client creation without API key
+- `new_with_client` - For advanced custom client configuration

--- a/crates/sparkscan/doc/new_with_client.md
+++ b/crates/sparkscan/doc/new_with_client.md
@@ -5,19 +5,18 @@ as well as port and a path stem if applicable.
 
 ## Usage with api.sparkscan.io
 
-When using the official SparkScan API at `api.sparkscan.io`, you must configure the `x-api-key` header:
+For most use cases with `api.sparkscan.io`, consider using `new_with_api_key` instead for simpler setup.
 
-> **Note**: Replace "your-api-key-here" with your actual SparkScan API key.
+For advanced configurations, you can manually configure the reqwest::Client:
+
+> **Note**: This example shows advanced client configuration. For simple API key setup, use `new_with_api_key`.
 
 ```rust
-use sparkscan::reqwest;
 use sparkscan::Client;
 
-let mut headers = reqwest::header::HeaderMap::new();
-headers.insert("x-api-key", "your-api-key-here".parse().unwrap());
-
+// Advanced configuration example
 let client = reqwest::ClientBuilder::new()
-    .default_headers(headers)
+    .timeout(std::time::Duration::from_secs(30))
     .build()
     .unwrap();
 

--- a/crates/sparkscan/doc/root_get.md
+++ b/crates/sparkscan/doc/root_get.md
@@ -11,19 +11,14 @@ Returns a simple response to verify API connectivity, useful for:
 > **Note**: This example demonstrates basic API connectivity testing.
 
 ```rust
-use sparkscan::{Client, reqwest};
+use sparkscan::Client;
 
 tokio_test::block_on(async {
-    // Configure client with API key
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("x-api-key", std::env::var("X_API_KEY").unwrap_or("test".to_string()).parse().unwrap());
-
-    let http_client = reqwest::ClientBuilder::new()
-        .default_headers(headers)
-        .build()
-        .unwrap();
-
-    let client = Client::new_with_client("https://api.sparkscan.io", http_client);
+    // Create client with API key from environment
+    let client = Client::new_with_api_key(
+        "https://api.sparkscan.io",
+        &std::env::var("X_API_KEY").unwrap_or("test".to_string())
+    );
     let response = client
         .root_get()
         .send()

--- a/crates/sparkscan/doc/token_issuer_lookup.md
+++ b/crates/sparkscan/doc/token_issuer_lookup.md
@@ -18,19 +18,14 @@ Accepts up to 100 items per request for efficient batch processing.
 > **Note**: The public keys and other values used in this example are for documentation testing purposes.
 
 ```rust
-use sparkscan::{Client, reqwest};
+use sparkscan::Client;
 
 tokio_test::block_on(async {
-    // Configure client with API key
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("x-api-key", std::env::var("X_API_KEY").unwrap_or("test".to_string()).parse().unwrap());
-
-    let http_client = reqwest::ClientBuilder::new()
-        .default_headers(headers)
-        .build()
-        .unwrap();
-
-    let client = Client::new_with_client("https://api.sparkscan.io", http_client);
+    // Create client with API key from environment
+    let client = Client::new_with_api_key(
+        "https://api.sparkscan.io",
+        &std::env::var("X_API_KEY").unwrap_or("test".to_string())
+    );
     
     // Lookup tokens by issuer public keys
     let request = sparkscan::types::TokenIssuerLookupRequest {

--- a/crates/sparkscan/src/lib.rs
+++ b/crates/sparkscan/src/lib.rs
@@ -1,8 +1,1 @@
 include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
-
-// Re-export reqwest for users of this crate
-pub use reqwest;
-
-// Re-export reqwest-middleware when tracing feature is enabled
-#[cfg(feature = "tracing")]
-pub use reqwest_middleware;


### PR DESCRIPTION
Implements a new `new_with_api_key` method for client initialization, enabling users to authenticate via an API key.

Simplifies client creation for production environments by directly handling the `x-api-key` header, and updates documentation examples to reflect this new recommended approach.